### PR TITLE
Remove unnecessary step for the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,8 @@ REPO_GIT_NAME ?= $(shell git config --get remote.origin.url)
 
 ITEMS       ?= 1 2
 IMAGE_TYPES ?= metanorma mn
-VERSIONS		?= 1.1.8 1.1.8
-ROOT_IMAGES ?= ubuntu:18.04 ubuntu:18.04
-RUBY_VER = 2.5.4
+VERSIONS		?= 1.1.8 1.2.1
+ROOT_IMAGES ?= ruby:2.5-slim-stretch ruby:2.5-slim-stretch
 
 # Getters
 GET_IMAGE_TYPE = $(word $1,$(IMAGE_TYPES))
@@ -88,9 +87,10 @@ $(3)/Gemfile.lock: $(3)/Gemfile
 
 $(3)/Dockerfile:
 	export ROOT_IMAGE=$(2); \
-	envsubst '$$$${ROOT_IMAGE}' < $$@.in > $$@
+	export METANORMA_VERSION=$(1); \
+	envsubst '$$$${ROOT_IMAGE},$$$${METANORMA_VERSION}' < $$@.in > $$@
 
-build-$(3): $(3)/Gemfile.lock $(3)/Dockerfile
+build-$(3): $(3)/Dockerfile
 	docker build --rm \
 		-t $(CONTAINER_LOCAL_NAME) \
 		-f $(3)/Dockerfile \
@@ -113,7 +113,7 @@ run-$(3):
 	$(DOCKER_RUN) -it --name=test-$(3) --entrypoint="" $(CONTAINER_REMOTE_NAME) /bin/bash; \
 
 test-$(3):
-	$(DOCKER_RUN) $(CONTAINER_LOCAL_NAME) /bin/bash 'metanorma -h'
+	$(DOCKER_RUN) $(CONTAINER_LOCAL_NAME) metanorma help
 
 kill-$(3):
 	docker kill test-$(3)

--- a/metanorma/Dockerfile.in
+++ b/metanorma/Dockerfile.in
@@ -2,76 +2,18 @@ FROM ${ROOT_IMAGE}
 
 MAINTAINER Open Source at Ribose <open.source@ribose.com>
 
+# install dependencies
 RUN apt-get update && apt-get install -y curl gnupg2
-
 RUN curl -sSL https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash -s
 
-# RVM version to install
-ARG RVM_VERSION=stable
-ENV RVM_VERSION=${RVM_VERSION}
-
-# RMV user to create
-ARG RVM_USER=metanorma
-ENV RVM_USER=${RVM_USER}
-
-# Install + verify RVM with gpg (https://rvm.io/rvm/security)
-RUN curl -sSL https://get.rvm.io | bash -s
-RUN cat /usr/local/rvm/gemsets/global.gems
-RUN echo "bundler" >> /usr/local/rvm/gemsets/global.gems \
-    && echo "rvm_silence_path_mismatch_check_flag=1" >> /etc/rvmrc \
-    && echo "install: --no-document" > /etc/gemrc
-
-# Workaround tty check, see https://github.com/hashicorp/vagrant/issues/1673#issuecomment-26650102
-RUN sed -i 's/^mesg n/tty -s \&\& mesg n/g' /root/.profile
-
-# Switch to a bash login shell to allow simple 'rvm' in RUN commands
-SHELL [ "/bin/bash", "-l", "-c" ]
-
-RUN rvm use ${RUBY_VER} --install --binary --fuzzy
-
-# Optional: child images can change to this user, or add 'rvm' group to other user
-# see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-RUN useradd -m --no-log-init -r -g rvm ${RVM_USER}
-
-RUN mkdir -p /metanorma
-COPY metanorma/Gemfile metanorma/Gemfile.lock /metanorma/
-
+# install metanorma toolchain
 WORKDIR /metanorma
-RUN which ruby
-RUN rvm use ${RUBY_VER}; \
-  gem update --system; \
-  gem install bundler \
-  && gem install rake \
-  && gem install sassc \
-  && bundle
+RUN gem install metanorma-cli -v "${METANORMA_VERSION}"
 
-# Add user "metanorma" as non-root user w/ sudo privileges
-RUN echo 'metanorma ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+# export java executable path
+ENV JAVA_HOME /usr/lib/jvm/default-java
+ENV PATH $PATH:$JAVA_HOME/bin
 
-VOLUME /metanorma
-
-# USER ${RVM_USER}
-
+# cleanup and set base entrypoint
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENTRYPOINT [ "/bin/bash", "-c", "-l" ]
-
-# Optional: child images can set Ruby versions to install (whitespace-separated)
-ONBUILD ARG RVM_RUBY_VERSIONS
-
-# Optional: child images can set default Ruby version (default is first version)
-ONBUILD ARG RVM_RUBY_DEFAULT
-
-# Child image runs this only if RVM_RUBY_VERSIONS is defined as ARG before the FROM line
-ONBUILD RUN if [ ! -z "${RVM_RUBY_VERSIONS}" ]; then \
-              VERSIONS="$(echo "${RVM_RUBY_VERSIONS}" | sed -E -e 's/\s+/\n/g')" \
-              && for v in ${VERSIONS}; do \
-                   echo "== docker-rvm: Installing ${v} ==" \
-                   && rvm install ${v}; \
-                 done \
-              && DEFAULT=${RVM_RUBY_DEFAULT:-$(echo "${VERSIONS}" | head -n1)} \
-              && echo "== docker-rvm: Setting default ${DEFAULT} ==" \
-              && rvm use --default "${DEFAULT}"; \
-            fi \
-            && rvm cleanup all \
-            && rm -rf /var/lib/apt/lists/*
+CMD ["metanorma"]

--- a/metanorma/Dockerfile.in
+++ b/metanorma/Dockerfile.in
@@ -7,8 +7,9 @@ RUN apt-get update && apt-get install -y curl gnupg2
 RUN curl -sSL https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash -s
 
 # install metanorma toolchain
-WORKDIR /metanorma
-RUN gem install metanorma-cli -v "${METANORMA_VERSION}"
+RUN mkdir -p /setup
+COPY ${METANORMA_IMAGE_NAME}/Gemfile /setup/Gemfile
+RUN cd /setup && bundle install
 
 # export java executable path
 ENV JAVA_HOME /usr/lib/jvm/default-java
@@ -16,4 +17,6 @@ ENV PATH $PATH:$JAVA_HOME/bin
 
 # cleanup and set base entrypoint
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /metanorma
 CMD ["metanorma"]


### PR DESCRIPTION
The current version of the image is explicitly installing rvm, setting up user, then installing ruby with bundler and then install everything using bundler which should not be necessary for our use case.

This commit changes this, now it usages a ruby slim image as a base, so we don't have to set up anything for ruby explicitly. This also installs gems directly and keeps the version number as a variable.

Related: #19