### PR TITLE
Enforce to use latest available bundler

### DIFF
--- a/metanorma/Dockerfile.in
+++ b/metanorma/Dockerfile.in
@@ -6,6 +6,9 @@ MAINTAINER Open Source at Ribose <open.source@ribose.com>
 RUN apt-get update && apt-get install -y curl gnupg2
 RUN curl -sSL https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash -s
 
+# install latest bundler
+RUN gem install bundler
+
 # install metanorma toolchain
 RUN mkdir -p /setup
 COPY ${METANORMA_IMAGE_NAME}/Gemfile /setup/Gemfile


### PR DESCRIPTION
The ruby image comes with a default bundler, which might no be up to date, so this commit enforces the installation of latest bundler so now both of the versions are available and it will choose the suitable version based on user's specification.

Related #19