### PR TITLE
Remove yq installation step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ script:
 - make test
 deploy:
 - provider: script
-  script: make tp-metanorma
+  script: make bsp-metanorma latest-tp-metanorma
   skip_cleanup: true
   on:
     tags: true
     branch: master
 - provider: script
-  script: make latest-tp-mn
+  script: make bsp-mn latest-tp-mn
   skip_cleanup: true
   on:
     branch: master

--- a/metanorma/Dockerfile.in
+++ b/metanorma/Dockerfile.in
@@ -4,7 +4,6 @@ MAINTAINER Open Source at Ribose <open.source@ribose.com>
 
 # install dependencies
 RUN apt-get update && apt-get install -y curl gnupg2 software-properties-common
-RUN curl -sSL https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN curl -sSL https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash -s
 
 # install latest bundler


### PR DESCRIPTION
Superseded by the incorporation of `yq` in metanorma-linux-setup:
- https://github.com/metanorma/metanorma-linux-setup/commit/0047985f548c23f636ef3e244dcbeb43921d4359