### PR TITLE
Lock bundler to a specific version

### DIFF
--- a/metanorma/Dockerfile.in
+++ b/metanorma/Dockerfile.in
@@ -13,7 +13,7 @@ RUN pip install --upgrade pip
 RUN pip install idnits xml2rfc --ignore-installed six chardet
 
 # install latest bundler
-RUN gem install bundler
+RUN gem install bundler -v "2.0.2"
 
 # install metanorma toolchain
 RUN mkdir -p /setup


### PR DESCRIPTION
There were some changes in bundler 2.0.2 to 2.1.0 and official ruby images that were causing issues with ruby gems executables. This is what causes our build process to fail.

There are some fixes coming up in ruby 2.7 image and next bundler release, but for now, let's lock the bundler version to 2.0.0.

Fixes: https://github.com/metanorma/metanorma-docker/issues/46
Details: https://github.com/bundler/bundler/issues/7494