### PR TITLE
Update bundler to the latest version

### DIFF
--- a/metanorma/Dockerfile.in
+++ b/metanorma/Dockerfile.in
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/share/man/man1 # https://bugs.debian.org/cgi-bin/bugreport.cgi
 RUN curl -sSL https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash -s
 
 # install latest bundler
-RUN gem install bundler -v "2.0.2"
+RUN gem install bundler
 
 # install metanorma toolchain
 RUN mkdir -p /setup


### PR DESCRIPTION
Recent release of bundler fixed the issue we were having earlier regarding missing executable. This commit changes the hard coded version to use the latest release of bundler, so the now docker
build should work as usual.


Closes #48