### PR TITLE
Allow install gems from GitHub Packages

### DIFF
--- a/.github/workflows/docker-metanorma.yml
+++ b/.github/workflows/docker-metanorma.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
+    - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
+      with:
+        token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
     - name: Build container
       run: |
         make build-metanorma
@@ -36,6 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
+    - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
+      with:
+        token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
     - name: Build container
       run: |
         make build-metanorma-ubuntu

--- a/.github/workflows/docker-mn.yml
+++ b/.github/workflows/docker-mn.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
+    - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
+      with:
+        token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
     - name: Build container
       run: |
         make build-mn
@@ -50,6 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
+    - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
+      with:
+        token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
     - name: Build container
       run: |
         make build-mn-ubuntu

--- a/Dockerfile.ruby.in
+++ b/Dockerfile.ruby.in
@@ -1,6 +1,9 @@
 FROM ruby:2.6-slim-buster
 USER root
 
+ARG BUNDLE_RUBYGEMS__PKG__GITHUB__COM
+ENV BUNDLE_RUBYGEMS__PKG__GITHUB__COM=$BUNDLE_RUBYGEMS__PKG__GITHUB__COM
+
 MAINTAINER Open Source at Ribose <open.source@ribose.com>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.ubuntu.in
+++ b/Dockerfile.ubuntu.in
@@ -1,9 +1,11 @@
 ARG RUBY_PATH=/usr/local/
 ARG RUBY_VERSION=2.6.5
+ARG BUNDLE_RUBYGEMS__PKG__GITHUB__COM
 
 FROM ubuntu:18.04 AS rubybuild
 ARG RUBY_PATH
 ARG RUBY_VERSION
+ARG BUNDLE_RUBYGEMS__PKG__GITHUB__COM
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -33,6 +35,7 @@ FROM ubuntu:18.04
 USER root
 MAINTAINER Open Source at Ribose <open.source@ribose.com>
 ARG RUBY_PATH
+ARG BUNDLE_RUBYGEMS__PKG__GITHUB__COM
 ENV PATH $RUBY_PATH/bin:$PATH
 COPY --from=rubybuild $RUBY_PATH $RUBY_PATH
 
@@ -58,6 +61,8 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 # install latest bundler
 RUN gem install bundler
+
+ENV BUNDLE_RUBYGEMS__PKG__GITHUB__COM=$BUNDLE_RUBYGEMS__PKG__GITHUB__COM
 
 # install metanorma toolchain
 COPY ${METANORMA_IMAGE_NAME}/Gemfile /setup/Gemfile

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ build-$(3): $(3)/Gemfile $(3)/Dockerfile
 		--label metanorma-container-version=$(1) \
 		--label metanorma-container-commit=$(CONTAINER_COMMIT) \
 		--label metanorma-container-commit-branch=$(CONTAINER_BRANCH) \
+		--build-arg BUNDLE_RUBYGEMS__PKG__GITHUB__COM \
 		.;\
 
 	$$(MAKE) clean-$(3)

--- a/metanorma/Gemfile.in
+++ b/metanorma/Gemfile.in
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
+source "https://rubygems.pkg.github.com/metanorma"
 
 gem "metanorma-cli", "${METANORMA_VERSION}"

--- a/mn/Gemfile.in
+++ b/mn/Gemfile.in
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
+source "https://rubygems.pkg.github.com/metanorma"
 
 gem "metanorma-cli", :github => "metanorma/metanorma-cli", :branch => "main"


### PR DESCRIPTION
This PR allow to install our private gems like metanorma-nist and metanorma-bsi on docker (because metanorma-cli depends on private gems)