### PR TITLE
Docker tag version must respect semver.org spec

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Docker tag version
       run: |
         curl -LO --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/main/gemver-to-semver.rb && chmod +x gemver-to-semver.rb
-        echo "DOCKER_TAG=$(./gemver-to-semver.rb ${METANORMA_CLI_VERSION})" >> $GITHUB_ENV
+        echo "DOCKER_TAG=$(./gemver-to-semver.rb --strip-prefix ${METANORMA_CLI_VERSION})" >> $GITHUB_ENV
 
     - name: Update version
       run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -38,6 +38,11 @@ jobs:
       run: |
         echo METANORMA_CLI_VERSION=${{ github.event.inputs.next_version }} >> ${GITHUB_ENV}
 
+    - name: Docker tag version
+      run: |
+        curl -LO --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/main/gemver-to-semver.rb && chmod +x gemver-to-semver.rb
+        echo "DOCKER_TAG=$(./gemver-to-semver.rb ${METANORMA_CLI_VERSION})" >> $GITHUB_ENV
+
     - name: Update version
       run: |
         echo "IMAGE_VERSION := ${METANORMA_CLI_VERSION}" > VERSION.mak
@@ -49,6 +54,6 @@ jobs:
     - name: Push commit and tag
       run: |
         git add VERSION.mak metanorma-ruby/Gemfile
-        git commit -m "Bump version to ${METANORMA_CLI_VERSION}"
-        git tag v${METANORMA_CLI_VERSION}
+        git commit -m "Bump version to ${DOCKER_TAG}"
+        git tag v${DOCKER_TAG}
         git push origin HEAD:${GITHUB_REF} --tags


### PR DESCRIPTION
### Intro

`docker/metadata-action` step force us to use semver.org. If we pass version which doesn't conform to semver.org spec if will 'silently fail' like this:

```
Warning: v1.5.15pre1 is not a valid semver. More info: https://semver.org/
Warning: v1.5.15pre1 is not a valid semver. More info: https://semver.org/
Warning: v1.5.15pre1 is not a valid semver. More info: https://semver.org/
Warning: No Docker image version has been generated. Check tags input.
Warning: No Docker tag has been generated. Check tags input.
```

### Proposed solution

A script which will be used for such conversion was added to `metanorma-build-scripts` collection https://github.com/metanorma/metanorma-build-scripts/blob/main/gemver-to-semver.rb

For now it supports `chocolatey` and `semver` flags

### Other possible solutions

 - Migrate to semver.org for our gems
 - Try to tune pattern here https://github.com/docker/metadata-action#semver (but I'm not sure that this is a good idea)

 - https://github.com/docker/metadata-action/issues/200 - added ticket to allow metadata step fails on wrong/unexpected input