### PR TITLE
Move yuichielectric/dive-action to separate job

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -175,6 +175,10 @@ jobs:
         echo "---"
         echo "::set-output name=full_name::$(cat /tmp/docker-tags.txt)"
 
+    - run: docker history ${{ steps.loaded_image.outputs.full_name }}
+
+    - run: docker inspect -f "{{ .Size }}" ${{ steps.loaded_image.outputs.full_name }}
+
     - uses: yuichielectric/dive-action@0.0.4
       with:
         image: ${{ steps.loaded_image.outputs.full_name }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -187,7 +187,6 @@ jobs:
   test:
     name: Test (${{ matrix.image_type }}-${{ matrix.root_image.id }}, ${{ matrix.flavor.id }})
     runs-on: ubuntu-latest
-    if: false # temporal block
     needs:
       - build
       - job_info

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -6,7 +6,6 @@ on:
     tags:
     - '*'
   pull_request:
-  repository_dispatch:
   workflow_dispatch:
 
 jobs:
@@ -22,11 +21,26 @@ jobs:
         echo "::set-output name=result::${CLI_VERSION}"
     - name: Show version number
       run: echo ${{ steps.version.outputs.result }}
+    - name: Retrieve tags
+      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set output variables
+      id: check
+      run: |
+        fpr="no"
+        tag=""
+        if [[ "${{ github.ref }}" == refs/heads/* ]]; then
+          tag="$(git tag --points-at HEAD)"
+        elif [[ "${{ github.ref }}" == refs/pull/* ]] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+          fpr="yes"
+        fi
+        echo "::set-output name=foreign_pr::${fpr}"
+        echo "::set-output name=head_tag::${tag}"
 
   build:
     name: Build (${{ matrix.image_type }}-${{ matrix.root_image.id }})
     runs-on: ubuntu-latest
     needs: job_info
+    if: "(github.event_name == 'push' && needs.job_info.outputs.head_tag == '') || github.event_name == 'pull_request'"
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -135,9 +135,55 @@ jobs:
         path: /tmp/docker-labels.txt
         retention-days: 1
 
+  lint:
+    name: Lint (${{ matrix.image_type }}-${{ matrix.root_image.id }})
+    runs-on: ubuntu-latest
+    needs: build
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        root_image:
+        - id: ruby
+          image: ruby:3.1.1-slim-bullseye
+        - id: ubuntu
+          image: ubuntu:20.04
+        - id: alpine
+          image: ruby:3.1.1-alpine
+        image_type:
+        - metanorma
+        experimental: [false]
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ${{ matrix.image_type }}-${{ matrix.root_image.id }}-${{ github.run_id }}
+        path: /tmp
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: tags-${{ matrix.image_type }}-${{ matrix.root_image.id }}-${{ github.run_id }}
+        path: /tmp
+
+    - id: loaded_image
+      name: Load image
+      run: |
+        docker load --input /tmp/docker-image.tar
+        echo "---"
+        cat /tmp/docker-tags.txt
+        echo "---"
+        echo "::set-output name=full_name::$(cat /tmp/docker-tags.txt)"
+
+    - uses: yuichielectric/dive-action@0.0.4
+      with:
+        image: ${{ steps.loaded_image.outputs.full_name }}
+        github-token: ${{ github.token }}
+
   test:
     name: Test (${{ matrix.image_type }}-${{ matrix.root_image.id }}, ${{ matrix.flavor.id }})
     runs-on: ubuntu-latest
+    if: false # temporal block
     needs:
       - build
       - job_info
@@ -207,11 +253,6 @@ jobs:
         cat /tmp/docker-tags.txt
         echo "---"
         echo "::set-output name=full_name::$(cat /tmp/docker-tags.txt)"
-
-    - uses: yuichielectric/dive-action@0.0.4
-      with:
-        image: ${{ steps.loaded_image.outputs.full_name }}
-        github-token: ${{ github.token }}
 
     - name: Fetch samples (${{ matrix.flavor.id }})
       uses: actions/checkout@v3

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -175,7 +175,7 @@ jobs:
         echo "---"
         echo "::set-output name=full_name::$(cat /tmp/docker-tags.txt)"
 
-    - run: docker history ${{ steps.loaded_image.outputs.full_name }}
+    - run: docker history --no-trunc ${{ steps.loaded_image.outputs.full_name }}
 
     - run: docker inspect -f "{{ .Size }}" ${{ steps.loaded_image.outputs.full_name }}
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -161,10 +161,13 @@ jobs:
         root_image:
         - id: ruby
           image: ruby:3.1.1-slim-bullseye
+          max_size: '1.5 GiB'
         - id: ubuntu
           image: ubuntu:20.04
+          max_size: '1.5 GB'
         - id: alpine
           image: ruby:3.1.1-alpine
+          max_size: '1.2 GB'
         image_type:
         - metanorma
         experimental: [false]
@@ -197,6 +200,11 @@ jobs:
       with:
         image: ${{ steps.loaded_image.outputs.full_name }}
         github-token: ${{ github.token }}
+
+    - uses: wemake-services/docker-image-size-limit@master
+      with:
+        image: ${{ steps.loaded_image.outputs.full_name }}
+        size: ${{ matrix.root_image.max_size }}
 
   test:
     name: Test (${{ matrix.image_type }}-${{ matrix.root_image.id }}, ${{ matrix.flavor.id }})

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,7 +9,8 @@ ARG METANORMA_IMAGE_NAME=metanorma
 RUN apk add --no-cache curl unzip bash make tzdata coreutils git coreutils \
   gcompat libxml2 libxslt libsass sassc \
   openjdk8-jre \
-  inkscape nss
+  inkscape nss && \
+  rm -rf /usr/share/inkscape/tutorials
 
 # Install plantuml
 RUN apk add --no-cache graphviz ttf-droid ttf-droid-nonlatin fontconfig

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,20 +6,19 @@ LABEL maintainer="open.source@ribose.com"
 ARG METANORMA_IMAGE_NAME=metanorma
 
 # Install dependencies
-RUN apk update && apk upgrade
-RUN apk add curl unzip bash make tzdata coreutils git coreutils \
+RUN apk add --no-cache curl unzip bash make tzdata coreutils git coreutils \
   gcc g++ musl-dev gcompat cmake \
   libxml2 libxml2-dev libxslt libxslt-dev libsass libsass-dev sassc \
   openjdk17 \
   inkscape nss
 
 # Install plantuml
-RUN apk add graphviz ttf-droid ttf-droid-nonlatin fontconfig
-RUN apk add plantuml --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk add --no-cache graphviz ttf-droid ttf-droid-nonlatin fontconfig
+RUN apk add --no-cache plantuml --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 
 # Install xml2rf
 ENV PYTHONUNBUFFERED=1
-RUN apk add python3 python3-dev && ln -sf python3 /usr/bin/python
+RUN apk add --no-cache python3 python3-dev && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip wheel
 RUN pip3 install --no-cache --upgrade idnits xml2rfc --ignore-installed six chardet

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,7 +7,7 @@ ARG METANORMA_IMAGE_NAME=metanorma
 
 # Install dependencies
 RUN apk add --no-cache curl unzip bash make tzdata coreutils git coreutils \
-  libxml2 libxml2-dev libxslt libxslt-dev libsass libsass-dev sassc \
+  gcompat libxml2 libxslt libsass sassc \
   openjdk8-jre \
   inkscape nss
 
@@ -17,9 +17,10 @@ RUN apk add --no-cache plantuml --repository=http://dl-cdn.alpinelinux.org/alpin
 
 # Install xml2rf
 ENV PYTHONUNBUFFERED=1
-RUN apk add --no-cache python3 python3-dev && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip wheel idnits xml2rfc --ignore-installed six chardet && rm -rf /root/.cache/pip
+RUN apk add --no-cache python3 python3-dev && ln -sf python3 /usr/bin/python && \
+    python3 -m ensurepip && \
+    pip3 install --no-cache --upgrade pip wheel idnits xml2rfc --ignore-installed six chardet && \
+    rm -rf /root/.cache/pip
 
 RUN mkdir -p /setup
 
@@ -31,11 +32,13 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 # --redownload need to fix rake Bundler::GemNotFound
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
   cd /setup && \
-  apk add --no-cache gcc g++ musl-dev gcompat cmake && \
+  apk add --no-cache gcc g++ musl-dev cmake libxml2-dev libxslt-dev libsass-dev && \
   bundle config set without development test && \
   bundle install --no-cache --redownload && \
-  apk del gcc g++ musl-dev gcompat cmake && \
-  rm -rf /root/.bundle/cache
+  apk del gcc g++ musl-dev cmake libxml2-dev libxslt-dev libsass-dev && \
+  rm -rf /root/.bundle/cache /usr/local/bundle/cache && \
+  find /usr/local/bundle/gems -type d -name 'spec' -prune -exec rm -r "{}" \; && \
+  find /usr/local/bundle/gems -type d -name 'test' -prune -exec rm -r "{}" \;
 
 # export java executable path
 ENV JAVA_HOME /usr/lib/jvm/default-jvm

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,9 +7,8 @@ ARG METANORMA_IMAGE_NAME=metanorma
 
 # Install dependencies
 RUN apk add --no-cache curl unzip bash make tzdata coreutils git coreutils \
-  gcc g++ musl-dev gcompat cmake \
   libxml2 libxml2-dev libxslt libxslt-dev libsass libsass-dev sassc \
-  openjdk17 \
+  openjdk8-jre \
   inkscape nss
 
 # Install plantuml
@@ -20,11 +19,7 @@ RUN apk add --no-cache plantuml --repository=http://dl-cdn.alpinelinux.org/alpin
 ENV PYTHONUNBUFFERED=1
 RUN apk add --no-cache python3 python3-dev && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip wheel
-RUN pip3 install --no-cache --upgrade idnits xml2rfc --ignore-installed six chardet
-
-# Delete cache
-RUN rm -rf /var/cache/apk/*
+RUN pip3 install --no-cache --upgrade pip wheel idnits xml2rfc --ignore-installed six chardet && rm -rf /root/.cache/pip
 
 RUN mkdir -p /setup
 
@@ -34,12 +29,13 @@ RUN gem install bundler
 # Install metanorma toolchain
 COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 # --redownload need to fix rake Bundler::GemNotFound
-# --no-cache https://github.com/rubygems/rubygems/issues/3225
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
   cd /setup && \
+  apk add --no-cache gcc g++ musl-dev gcompat cmake && \
   bundle config set without development test && \
   bundle install --no-cache --redownload && \
-  rm -rf /usr/local/bundle/cache
+  apk del gcc g++ musl-dev gcompat cmake && \
+  rm -rf /root/.bundle/cache
 
 # export java executable path
 ENV JAVA_HOME /usr/lib/jvm/default-jvm

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -38,6 +38,7 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 # --no-cache https://github.com/rubygems/rubygems/issues/3225
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
   cd /setup && \
+  bundle config set without development test \
   bundle install --no-cache --redownload && \
   rm -rf /usr/local/bundle/cache
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -37,7 +37,7 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 # --no-cache https://github.com/rubygems/rubygems/issues/3225
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
   cd /setup && \
-  bundle config set without development test \
+  bundle config set without development test && \
   bundle install --no-cache --redownload && \
   rm -rf /usr/local/bundle/cache
 

--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -7,20 +7,18 @@ ARG METANORMA_IMAGE_NAME=metanorma
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# install dependencies
-RUN apt-get update && \
-  apt-get install -y curl gnupg2 software-properties-common python3-pip snapd && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-
 RUN mkdir -p /setup
 
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199#23
 RUN mkdir -p /usr/share/man/man1
 
 COPY ./ubuntu.sh /setup/ubuntu.sh
-RUN apt-get update && bash -c /setup/ubuntu.sh && \
-  apt-get clean && rm -rf /var/lib/apt/lists/* && \
-  rm -rf /root/.cpan/build
+
+# install dependencies
+RUN apt-get update && \
+  apt-get install -y curl gnupg2 software-properties-common python3-pip snapd && \
+  bash -c /setup/ubuntu.sh && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install latest bundler
 RUN gem install bundler

--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -7,32 +7,40 @@ ARG METANORMA_IMAGE_NAME=metanorma
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN mkdir -p /setup
-
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199#23
 RUN mkdir -p /usr/share/man/man1
 
-COPY ./ubuntu.sh /setup/ubuntu.sh
-
 # install dependencies
 RUN apt-get update && \
-  apt-get install -y curl gnupg2 software-properties-common python3-pip snapd && \
-  bash -c /setup/ubuntu.sh && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# install latest bundler
-RUN gem install bundler
+    apt-get --no-install-recommends install -y curl git make sassc && \
+    apt-get update && curl -L "https://raw.githubusercontent.com/metanorma/plantuml-install/main/ubuntu.sh" | bash && \
+    apt-get --no-install-recommends install -y software-properties-common gnupg2 && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9DA4BD18B9A06DE3 && \
+    add-apt-repository ppa:inkscape.dev/stable && \
+    apt-get --no-install-recommends install -y inkscape && \
+    rm -rf /usr/share/inkscape/tutorials && \
+    apt-get --no-install-recommends install -y python3-pip python3-setuptools python3-wheel && \
+    pip3 install --no-cache-dir idnits xml2rfc --ignore-installed six chardet && rm -rf /root/.cache/pip && \
+    apt-get purge -y python3-pip python3-setuptools python3-wheel && \
+    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # install metanorma toolchain
+RUN mkdir -p /setup
 COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
-# --redownload need to fix rake Bundler::GemNotFound
-# --no-cache https://github.com/rubygems/rubygems/issues/3225
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
     --mount=type=secret,id=gemrc_config,dst=$GEM_HOME/.gemrc \
+  gem install bundler && \
+  apt-get update && apt-get --no-install-recommends install -y gcc g++ cmake libxml2-dev libxslt-dev libsass-dev && \
   cd /setup && \
   bundle config set without development test && \
   bundle install --no-cache --redownload && \
-  rm -rf /usr/local/bundle/cache
+  rm -rf /usr/local/bundle/cache && \
+  find /usr/local/bundle/gems -type d -name 'spec' -prune -exec rm -r "{}" \; && \
+  find /usr/local/bundle/gems -type d -name 'test' -prune -exec rm -r "{}" \; && \
+  apt-get purge -y gcc g++ ruby-dev cmake libxml2-dev libxslt-dev libsass-dev && \
+  apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # export java executable path
 ENV JAVA_HOME /usr/lib/jvm/default-java

--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -30,7 +30,7 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
     --mount=type=secret,id=gemrc_config,dst=$GEM_HOME/.gemrc \
   cd /setup && \
-  bundle config set without development test \
+  bundle config set without development test && \
   bundle install --no-cache --redownload && \
   rm -rf /usr/local/bundle/cache
 

--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -32,6 +32,7 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 RUN --mount=type=secret,id=bundle_config,dst=/usr/local/bundle/config \
     --mount=type=secret,id=gemrc_config,dst=$GEM_HOME/.gemrc \
   cd /setup && \
+  bundle config set without development test \
   bundle install --no-cache --redownload && \
   rm -rf /usr/local/bundle/cache
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -25,12 +25,10 @@ RUN apt-get update && \
       snapd && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-build \
-  && $RUBY_PATH/plugins/ruby-build/install.sh
-
-RUN ruby-build $RUBY_VERSION $RUBY_PATH && \
-  apt-get clean && rm -rf /var/lib/apt/lists/* && \
-  rm -rf /root/.cpan/build
+RUN git clone https://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-build && \
+    $RUBY_PATH/plugins/ruby-build/install.sh && \
+    ruby-build $RUBY_VERSION $RUBY_PATH && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM ubuntu:20.04
 USER root
@@ -78,6 +76,7 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 RUN --mount=type=secret,id=bundle_config,dst=$GEM_HOME/config \
     --mount=type=secret,id=gemrc_config,dst=$GEM_HOME/.gemrc \
   cd /setup && \
+  bundle config set without development test \
   bundle install --no-cache --verbose && \
   rm -rf /usr/local/bundle/cache
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -23,9 +23,7 @@ RUN apt-get update && \
       libgdbm6 \
       libgdbm-dev \
       snapd && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-build && \
+    git clone https://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-build && \
     $RUBY_PATH/plugins/ruby-build/install.sh && \
     ruby-build $RUBY_VERSION $RUBY_PATH && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -43,18 +41,14 @@ ENV CONTAINER_TIMEZONE=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && \
   echo $CONTAINER_TIMEZONE > /etc/timezone
 
+RUN mkdir -p /setup
+COPY ./ubuntu.sh /setup/ubuntu.sh
+
 # install dependencies
 RUN apt-get update && apt-get install -y \
   curl gnupg2 software-properties-common python3-pip && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /setup
-
-COPY ./ubuntu.sh /setup/ubuntu.sh
-RUN apt-get update && \
   bash -c /setup/ubuntu.sh && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # From https://github.com/docker-library/ruby/blob/master/
 #   Dockerfile-debian.template

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -26,6 +26,7 @@ RUN apt-get update && \
     git clone https://github.com/rbenv/ruby-build.git $RUBY_PATH/plugins/ruby-build && \
     $RUBY_PATH/plugins/ruby-build/install.sh && \
     ruby-build $RUBY_VERSION $RUBY_PATH && \
+    rm -rf ~/.rbenv/cache && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM ubuntu:20.04
@@ -41,14 +42,22 @@ ENV CONTAINER_TIMEZONE=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && \
   echo $CONTAINER_TIMEZONE > /etc/timezone
 
-RUN mkdir -p /setup
-COPY ./ubuntu.sh /setup/ubuntu.sh
-
 # install dependencies
-RUN apt-get update && apt-get install -y \
-  curl gnupg2 software-properties-common python3-pip && \
-  bash -c /setup/ubuntu.sh && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y curl git make sassc && \
+    apt-get update && curl -L "https://raw.githubusercontent.com/metanorma/plantuml-install/main/ubuntu.sh" | bash && \
+    apt-get purge -y default-jre && \
+    apt-get autoremove -y && \
+    apt-get --no-install-recommends install -y openjdk-8-jre software-properties-common && \
+    add-apt-repository ppa:inkscape.dev/stable && \
+    apt-get --no-install-recommends install -y inkscape && \
+    rm -rf /usr/share/inkscape/tutorials && \
+    apt-get --no-install-recommends install -y python3-pip python3-setuptools python3-wheel && \
+    pip3 install --no-cache-dir idnits xml2rfc --ignore-installed six chardet && rm -rf /root/.cache/pip && \
+    apt-get purge -y python3-pip python3-setuptools python3-wheel && \
+    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # From https://github.com/docker-library/ruby/blob/master/
 #   Dockerfile-debian.template
@@ -61,18 +70,23 @@ ENV PATH $GEM_HOME/bin:$PATH
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 # End From
 
-# install latest bundler
-RUN gem install bundler
-
 # install metanorma toolchain
+RUN mkdir -p /setup
 COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
-# --no-cache https://github.com/rubygems/rubygems/issues/3225
 RUN --mount=type=secret,id=bundle_config,dst=$GEM_HOME/config \
     --mount=type=secret,id=gemrc_config,dst=$GEM_HOME/.gemrc \
+  gem install bundler && \
+  apt-get update && \
+  apt-get --no-install-recommends install -y make gcc g++ ruby-dev cmake libxml2-dev libxslt-dev libsass-dev && \
   cd /setup && \
   bundle config set without development test && \
   bundle install --no-cache --verbose && \
-  rm -rf /usr/local/bundle/cache
+  rm -rf /usr/local/bundle/cache && \
+  find /usr/local/bundle/gems -type d -name 'spec' -prune -exec rm -r "{}" \; && \
+  find /usr/local/bundle/gems -type d -name 'test' -prune -exec rm -r "{}" \; && \
+  apt-get purge -y make gcc g++ ruby-dev cmake libxml2-dev libxslt-dev libsass-dev && \
+  apt-get autoremove -y && apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # export java executable path
 ENV JAVA_HOME /usr/lib/jvm/default-java

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -70,7 +70,7 @@ COPY $METANORMA_IMAGE_NAME/Gemfile /setup/Gemfile
 RUN --mount=type=secret,id=bundle_config,dst=$GEM_HOME/config \
     --mount=type=secret,id=gemrc_config,dst=$GEM_HOME/.gemrc \
   cd /setup && \
-  bundle config set without development test \
+  bundle config set without development test && \
   bundle install --no-cache --verbose && \
   rm -rf /usr/local/bundle/cache
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,10 @@ image:https://github.com/metanorma/metanorma-docker/workflows/docker-mn/badge.sv
 image:https://img.shields.io/github/issues-pr-raw/metanorma/metanorma-docker.svg["Pull Requests", link="https://github.com/metanorma/metanorma-docker/pulls"]
 image:https://img.shields.io/github/commits-since/metanorma/metanorma-docker/latest.svg["Commits since latest",link="https://github.com/metanorma/metanorma-docker/releases"]
 
+image:https://badgen.net/docker/size/metanorma/metanorma/alpine-latest?icon=docker&label=alpine["metanorma:alpine-latest", link="https://hub.docker.com/r/metanorma/metanorma/tags?name=alpine"]
+image:https://badgen.net/docker/size/metanorma/metanorma/ubuntu-latest?icon=docker&label=ubuntu["metanorma:ubuntu-latest", link="https://hub.docker.com/r/metanorma/metanorma/tags?name=ubuntu"]
+image:https://badgen.net/docker/size/metanorma/metanorma/ruby-latest?icon=docker&label=ruby["metanorma:ruby-latest", link="https://hub.docker.com/r/metanorma/metanorma/tags?name=ruby"]
+
 https://hub.docker.com/r/metanorma/metanorma/tags[Docker Hub: metanorma/metanorma]
 
 == Purpose


### PR DESCRIPTION
 - #147 

### What's done (alpine)

 - OpenJDK downgrade to 8: -100MB
 - Uninstall gcc/g++: -~200MB
 - Remove test files from gems: ~100MB

Potential:
 - Inkscape takes ~200Mb, this direction can be investigated, probably we can rebuild inkscape to keep it minimal
 - python with packages takes ~170Mb, also looks too big