### PR TITLE
Install fontconfig ttf-dejavu explicitly

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,7 +8,7 @@ ARG METANORMA_IMAGE_NAME=metanorma
 # Install dependencies
 RUN apk add --no-cache curl unzip bash make tzdata coreutils git coreutils \
   gcompat libxml2 libxslt libsass sassc \
-  openjdk8-jre \
+  openjdk8-jre fontconfig ttf-dejavu \
   inkscape nss && \
   rm -rf /usr/share/inkscape/tutorials
 


### PR DESCRIPTION
### Intro

During https://github.com/metanorma/packed-mn/pull/201 was observed Exception:

> Exception in thread "main" java.lang.UnsatisfiedLinkError: no fontmanager in java.library.path: [/usr/lib/jvm/java-10-openjdk/lib/server, /usr/lib/jvm/java-10-openjdk/lib, /usr/lib/jvm/java-10-openjdk/../lib, /usr/java/packages/lib, /usr/lib64, /lib64, /lib, /usr/lib]

[The fix](https://stackoverflow.com/questions/37251309/no-fontmanager-in-java-library-path) is to install `fontconfig` and `ttf-dejavu` packages

This doesn't happen on our alpine docker image probably because those deps installed implicitly.

But it seems that it make sense to install them explicitly in case if base image will be changed