### PR TITLE
Fix lxml installation requirements

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -52,7 +52,7 @@ RUN apt-get update && \
     add-apt-repository ppa:inkscape.dev/stable && \
     apt-get --no-install-recommends install -y inkscape && \
     rm -rf /usr/share/inkscape/tutorials && \
-    apt-get --no-install-recommends install -y python3-pip python3-setuptools python3-wheel && \
+    apt-get --no-install-recommends install -y python3-pip python3-setuptools python3-wheel python3-lxml && \
     pip3 install --no-cache-dir idnits xml2rfc --ignore-installed six chardet && rm -rf /root/.cache/pip && \
     apt-get purge -y python3-pip python3-setuptools python3-wheel && \
     apt-get autoremove -y && apt-get clean && \


### PR DESCRIPTION
```
...
69.21   Downloading lxml-5.0.0.tar.gz (3.8 MB)
69.64     ERROR: Command errored out with exit status 1:
69.64      command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-1bdyu8wd/lxml/setup.py'"'"'; __file__='"'"'/tmp/pip-install-1bdyu8wd/lxml/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-1bdyu8wd/lxml/pip-egg-info
69.64          cwd: /tmp/pip-install-1bdyu8wd/lxml/
69.64     Complete output (3 lines):
69.64     Building lxml version 5.0.0.
69.64     Building without Cython.
69.64     Error: Please make sure the libxml2 and libxslt development packages are installed.
69.64     ----------------------------------------
69.69 ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Full log: https://github.com/metanorma/metanorma-docker/actions/runs/7359602908/job/20034803250#step:8:3575