### PR TITLE
#193: add Dockerfile.windows and sample workflow

### DIFF
--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -46,12 +46,6 @@ jobs:
           username: ${{ secrets.DOCKER_LOGIN_USERNAME }}
           password: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: metanorma-ci
-          password: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
-
       - name: Build Docker Image
         run: |
           docker build --pull --no-cache -t ${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }} -f Dockerfile.windows --build-arg BASE_IMAGE=${{ matrix.root_image.base_image }} .

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -13,12 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_USERNAME }}
-  DOCKER_PASSWORD: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
   IMAGE_NAME: "docker.io/metanorma/metanorma-windows"
 
 jobs:
+  debug-overrides:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Override IMAGE_NAME if secrets.IMAGE_NAME is set
+        run: |
+          if [[ -n "${{ secrets.IMAGE_NAME }}" ]]; then
+            echo "IMAGE_NAME=${{ secrets.IMAGE_NAME }}" >> $GITHUB_ENV
+          fi
+      - name: Print IMAGE_NAME
+        run: echo "$IMAGE_NAME"
+
   build-windows-images:
+    needs: debug-overrides
     strategy:
       matrix:
         root_image:
@@ -66,24 +76,16 @@ jobs:
           password: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
 
       - name: Create and Push Docker Manifest
-        run: |
-          MANIFEST_TAG=${{ env.IMAGE_NAME }}:latest
-          
-          docker manifest create $MANIFEST_TAG \
-            ${{ env.IMAGE_NAME }}:ltsc2019 \
-            ${{ env.IMAGE_NAME }}:ltsc2022 \
+        uses: Noelware/docker-manifest-action@0.4.3
+        with:
+          inputs: ${{ env.IMAGE_NAME }}:latest
+          images: |
+            ${{ env.IMAGE_NAME }}:ltsc2019
+            ${{ env.IMAGE_NAME }}:ltsc2022
             ${{ env.IMAGE_NAME }}:ltsc2025
+          #annotations: |
+          #  ${{ env.IMAGE_NAME }}:ltsc2019 os=windows arch=amd64 os.version=10.0.17763.6893
+          #  ${{ env.IMAGE_NAME }}:ltsc2022 os=windows arch=amd64 os.version=10.0.20348.3207
+          #  ${{ env.IMAGE_NAME }}:ltsc2025 os=windows arch=amd64 os.version=10.0.26100.3194
+          push: true
 
-          docker manifest annotate $MANIFEST_TAG \
-            ${{ env.IMAGE_NAME }}:ltsc2019 \
-            --os windows --arch amd64 --os-version "10.0.17763.6893"
-
-          docker manifest annotate $MANIFEST_TAG \
-            ${{ env.IMAGE_NAME }}:ltsc2022 \
-            --os windows --arch amd64 --os-version "10.0.20348.3207"
-
-          docker manifest annotate $MANIFEST_TAG \
-            ${{ env.IMAGE_NAME }}:ltsc2025 \
-            --os windows --arch amd64 --os-version "10.0.26100.3194"
-
-          docker manifest push $MANIFEST_TAG

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
-  IMAGE_NAME: "metanorma-windows"
   REGISTRY: "docker.io"
+  IMAGE_NAME: "${{ env.REGISTRY }}/metanorma/metanorma-windows"
 
 jobs:
   build-windows-images:
@@ -38,69 +38,61 @@ jobs:
            # Windows Server 2019 with .NET Framework 4.8 required for Chocolatey
            base_image: "mcr.microsoft.com/dotnet/framework/runtime:4.8"
     runs-on: ${{ matrix.root_image.os }}
+    env:
+      IMAGE_TAG: "${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub (if credentials are provided)
-        if: env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != ''
-        run: |
-          echo "${{ env.DOCKER_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: metanorma-ci
+          password: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 
       - name: Build Docker Image
         run: |
-          $imageTag = "${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}"
-          docker build --pull --no-cache -t $imageTag -f Dockerfile.windows --build-arg BASE_IMAGE=${{ matrix.root_image.base_image }} .
-
-      - name: Save Docker Image as Artifact (if credentials are not provided)
-        if: env.DOCKER_USERNAME == '' || env.DOCKER_PASSWORD == ''
-        run: |
-          $imageTag = "${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}"
-          $outputFile = "${{ env.IMAGE_NAME }}-${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}.tar"
-          docker save -o $outputFile $imageTag
+          docker build --pull --no-cache -t ${{ env.IMAGE_TAG }} -f Dockerfile.windows --build-arg BASE_IMAGE=${{ matrix.root_image.base_image }} .
         shell: pwsh
 
-      - name: Upload Docker Image (if credentials are not provided)
-        uses: actions/upload-artifact@v4
-        if: env.DOCKER_USERNAME == '' || env.DOCKER_PASSWORD == ''
-        with:
-          name: ${{ env.IMAGE_NAME }}-${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}
-          path: ${{ env.IMAGE_NAME }}-${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}.tar
-
-      - name: Push Docker Image to Docker Hub (if credentials are provided)
-        if: env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != ''
+      - name: Push Docker Image to Docker Hub
         run: |
-          $imageTag = "${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}"
-          docker push $imageTag
+          docker push ${{ env.IMAGE_TAG }}
         shell: pwsh
 
   create-manifest:
     needs: build-windows-images
     runs-on: ubuntu-latest
     steps:
-      - name: Log in to Docker Hub
-        run: |
-          echo "${{ env.DOCKER_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
 
       - name: Create and Push Docker Manifest
         run: |
-          MANIFEST_TAG=${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          MANIFEST_TAG=${{ env.IMAGE_NAME }}:latest
           
           docker manifest create $MANIFEST_TAG \
-            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2019 \
-            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2022 \
-            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2025
+            ${{ env.IMAGE_NAME }}:ltsc2019 \
+            ${{ env.IMAGE_NAME }}:ltsc2022 \
+            ${{ env.IMAGE_NAME }}:ltsc2025
 
           docker manifest annotate $MANIFEST_TAG \
-            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2019 \
+            ${{ env.IMAGE_NAME }}:ltsc2019 \
             --os windows --arch amd64 --os-version "10.0.17763.6893"
 
           docker manifest annotate $MANIFEST_TAG \
-            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2022 \
+            ${{ env.IMAGE_NAME }}:ltsc2022 \
             --os windows --arch amd64 --os-version "10.0.20348.3207"
 
           docker manifest annotate $MANIFEST_TAG \
-            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2025 \
+            ${{ env.IMAGE_NAME }}:ltsc2025 \
             --os windows --arch amd64 --os-version "10.0.26100.3194"
 
           docker manifest push $MANIFEST_TAG

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -13,22 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: "docker.io/metanorma/metanorma-windows"
+  IMAGE_NAME: "docker.io/alexsc01/metanorma-windows"
 
 jobs:
-  debug-overrides:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Override IMAGE_NAME if secrets.IMAGE_NAME is set
-        run: |
-          if [[ -n "${{ secrets.IMAGE_NAME }}" ]]; then
-            echo "IMAGE_NAME=${{ secrets.IMAGE_NAME }}" >> $GITHUB_ENV
-          fi
-      - name: Print IMAGE_NAME
-        run: echo "$IMAGE_NAME"
-
   build-windows-images:
-    needs: debug-overrides
     strategy:
       matrix:
         root_image:

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -15,8 +15,7 @@ concurrency:
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
-  REGISTRY: "docker.io"
-  IMAGE_NAME: "${{ env.REGISTRY }}/metanorma/metanorma-windows"
+  IMAGE_NAME: "docker.io/metanorma/metanorma-windows"
 
 jobs:
   build-windows-images:

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -1,6 +1,11 @@
 name: build-push-windows
 
 on:
+  push:
+    branches: [ main ]
+    tags:
+    - '*'
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -67,13 +67,5 @@ jobs:
         uses: Noelware/docker-manifest-action@0.4.3
         with:
           inputs: ${{ env.IMAGE_NAME }}:latest
-          images: |
-            ${{ env.IMAGE_NAME }}:ltsc2019
-            ${{ env.IMAGE_NAME }}:ltsc2022
-            ${{ env.IMAGE_NAME }}:ltsc2025
-          #annotations: |
-          #  ${{ env.IMAGE_NAME }}:ltsc2019 os=windows arch=amd64 os.version=10.0.17763.6893
-          #  ${{ env.IMAGE_NAME }}:ltsc2022 os=windows arch=amd64 os.version=10.0.20348.3207
-          #  ${{ env.IMAGE_NAME }}:ltsc2025 os=windows arch=amd64 os.version=10.0.26100.3194
+          images: ${{ env.IMAGE_NAME }}:ltsc2019,${{ env.IMAGE_NAME }}:ltsc2022,${{ env.IMAGE_NAME }}:ltsc2025
           push: true
-

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -37,8 +37,6 @@ jobs:
            # Windows Server 2019 with .NET Framework 4.8 required for Chocolatey
            base_image: "mcr.microsoft.com/dotnet/framework/runtime:4.8"
     runs-on: ${{ matrix.root_image.os }}
-    env:
-      IMAGE_TAG: "${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,12 +54,12 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker build --pull --no-cache -t ${{ env.IMAGE_TAG }} -f Dockerfile.windows --build-arg BASE_IMAGE=${{ matrix.root_image.base_image }} .
+          docker build --pull --no-cache -t ${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }} -f Dockerfile.windows --build-arg BASE_IMAGE=${{ matrix.root_image.base_image }} .
         shell: pwsh
 
       - name: Push Docker Image to Docker Hub
         run: |
-          docker push ${{ env.IMAGE_TAG }}
+          docker push ${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}
         shell: pwsh
 
   create-manifest:

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -1,0 +1,101 @@
+name: build-push-windows
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+env:
+  DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_LOGIN_PASSWORD }}
+  IMAGE_NAME: "metanorma-windows"
+  REGISTRY: "docker.io"
+
+jobs:
+  build-windows-images:
+    strategy:
+      matrix:
+        root_image:
+         - os: windows-2025
+           # Can be obtained using `docker manifest inspect mcr.microsoft.com/windows/servercore:ltsc2025`
+           os_version: "10.0.26100.3194"
+           base_id: ltsc2025
+           base_image: "mcr.microsoft.com/windows/servercore:ltsc2025"
+         - os: windows-2022
+           os_version: "10.0.20348.3207"
+           base_id: ltsc2022
+           base_image: "mcr.microsoft.com/windows/servercore:ltsc2022"
+         - os: windows-2019
+           os_version: "10.0.17763.6893"
+           base_id: ltsc2019
+           # Windows Server 2019 with .NET Framework 4.8 required for Chocolatey
+           base_image: "mcr.microsoft.com/dotnet/framework/runtime:4.8"
+    runs-on: ${{ matrix.root_image.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub (if credentials are provided)
+        if: env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != ''
+        run: |
+          echo "${{ env.DOCKER_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build Docker Image
+        run: |
+          $imageTag = "${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}"
+          docker build --pull --no-cache -t $imageTag -f Dockerfile.windows --build-arg BASE_IMAGE=${{ matrix.root_image.base_image }} .
+
+      - name: Save Docker Image as Artifact (if credentials are not provided)
+        if: env.DOCKER_USERNAME == '' || env.DOCKER_PASSWORD == ''
+        run: |
+          $imageTag = "${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}"
+          $outputFile = "${{ env.IMAGE_NAME }}-${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}.tar"
+          docker save -o $outputFile $imageTag
+        shell: pwsh
+
+      - name: Upload Docker Image (if credentials are not provided)
+        uses: actions/upload-artifact@v4
+        if: env.DOCKER_USERNAME == '' || env.DOCKER_PASSWORD == ''
+        with:
+          name: ${{ env.IMAGE_NAME }}-${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}
+          path: ${{ env.IMAGE_NAME }}-${{ matrix.root_image.os }}-${{ matrix.root_image.base_id }}.tar
+
+      - name: Push Docker Image to Docker Hub (if credentials are provided)
+        if: env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != ''
+        run: |
+          $imageTag = "${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.root_image.base_id }}"
+          docker push $imageTag
+        shell: pwsh
+
+  create-manifest:
+    needs: build-windows-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        run: |
+          echo "${{ env.DOCKER_PASSWORD }}" | docker login ${{ env.REGISTRY }} -u "${{ env.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Create and Push Docker Manifest
+        run: |
+          MANIFEST_TAG=${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          
+          docker manifest create $MANIFEST_TAG \
+            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2019 \
+            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2022 \
+            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2025
+
+          docker manifest annotate $MANIFEST_TAG \
+            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2019 \
+            --os windows --arch amd64 --os-version "10.0.17763.6893"
+
+          docker manifest annotate $MANIFEST_TAG \
+            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2022 \
+            --os windows --arch amd64 --os-version "10.0.20348.3207"
+
+          docker manifest annotate $MANIFEST_TAG \
+            ${{ env.REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:ltsc2025 \
+            --os windows --arch amd64 --os-version "10.0.26100.3194"
+
+          docker manifest push $MANIFEST_TAG

--- a/.github/workflows/build-push-windows.yml
+++ b/.github/workflows/build-push-windows.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: "docker.io/alexsc01/metanorma-windows"
+  IMAGE_NAME: "docker.io/metanorma/metanorma-windows"
 
 jobs:
   build-windows-images:

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,66 @@
+ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022
+# mcr.microsoft.com/dotnet/framework/runtime:4.8 - Windows Server 2019 with .NET Framework 4.8 needed for Chocolatey
+# mcr.microsoft.com/windows/servercore:ltsc2022 - Windows Server 2022
+# mcr.microsoft.com/windows/servercore:ltsc2025 - Windows Server 2025
+
+FROM $BASE_IMAGE
+
+ARG RUBY_VERSION=3.3.6.2
+
+LABEL maintainer="open.source@ribose.com" \
+      org.opencontainers.image.authors="open.source@ribose.com" \
+      org.opencontainers.image.url="https://www.metanorma.org" \
+      org.opencontainers.image.documentation="https://www.metanorma.org" \
+      org.opencontainers.image.title="Metanorma" \
+      org.opencontainers.image.description="Metanorma document processing toolchain (Windows variant)"
+
+# Install Chocolatey
+RUN powershell -Command \
+    Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
+    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install build and runtime dependencies using Chocolatey
+RUN choco install -y git wget 7zip msys2 make curl inkscape plantuml python3 \
+    && refreshenv
+
+# Install MinGW and MSYS2 dependencies (mingw-w64-x86_64-libyaml is needed for the psych gem)
+RUN setx PATH "%PATH%;C:\tools\msys64\usr\bin;C:\tools\msys64\mingw64\bin" \
+    && echo "Updating MSYS2..." \
+    && C:\tools\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu" \
+    && C:\tools\msys64\usr\bin\bash -lc "pacman --noconfirm -S base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-make mingw-w64-x86_64-libyaml"
+
+# Install Ruby using Chocolatey/RubyInstaller
+RUN choco install -y ruby --version=%RUBY_VERSION%
+
+# Verify installation
+RUN ruby -v
+
+# Install XML2RFC
+RUN python -m pip install --upgrade pip && \
+    python -m pip install --no-cache-dir wheel idnits xml2rfc --ignore-installed six chardet
+
+# Install bundler, fontist and metanorma dependencies
+RUN gem install "bundler:~>2.6.5" fontist
+
+# Copy and install metanorma gem
+COPY Gemfile c:/setup/Gemfile
+
+RUN cd c:/setup && bundle install
+
+# Update fontist
+RUN fontist update
+
+# Set environment variables
+ENV BUNDLE_GEMFILE=C:/setup/Gemfile \
+    RELATON_FETCH_PARALLEL=1
+
+# Configure volume for fonts
+VOLUME c:/Users/ContainerAdministrator/.fontist/fonts
+
+# Set working directory
+WORKDIR c:/metanorma
+
+# Entrypoint and default command
+ENTRYPOINT ["cmd.exe", "/c"]
+CMD ["metanorma"]


### PR DESCRIPTION
- Add Dockerfile for Native Windows Containers and sample build workflow
- Built images are available under `alexsc01/metanorma-windows` for Windows Server 2019/2022/2025
- Host OS version should match Docker image base OS version, so multiple images needs to be built using the same Dockerfile, but different base images (`FROM ...`)
- It's possible to run older base images on newer hosts using Hyper-V isolation `docker run --isolation=hyperv ...` (https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2025%2Cwindows-11#hyper-v-isolation-for-containers). Make sure HyperV is enabled on the host
- Each Docker image is built using corresponding runner (`windows-2019`/`windows-2022`/`windows-2025`) and all images are combined under the same tag using Docker Manifest

### Possible further enhancements
- Reduce image size
- Investigate ability to build not yet supported Windows images (specifically, desktop Windows) using some build-time isolation similar to `--isolation=hyperv`

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
