### PR TITLE
chore(workflow): decrease build time with matrix

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -290,7 +290,7 @@ jobs:
           metanorma site generate --strict --agree-to-terms .
 
   publish:
-    name: Build+publish (${{ matrix.image_type }}-${{ matrix.root_image.id }}
+    name: Build+publish (${{ matrix.image_type }}-${{ matrix.root_image.id }}-${{ matrix.platforms }})
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs:
@@ -311,6 +311,11 @@ jobs:
 
         image_type:
         - metanorma
+
+        platforms:
+        - linux/amd64
+        - linux/arm64
+
         # - mn
 
     steps:
@@ -396,7 +401,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platforms }}
         push: true
         file: Dockerfile.${{ matrix.root_image.id }}
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
From @njfamirm. Testing if the parallelized publication will work. I'm not sure if it will in a PR because if I remember properly, publication only occurs after merging to main.