### PR TITLE
#208 - upgrade Windows Docker to latest Ruby 3.4

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -30,13 +30,13 @@ RUN setx PATH "%PATH%;C:\tools\msys64\usr\bin;C:\tools\msys64\mingw64\bin" \
     && C:\tools\msys64\usr\bin\bash -lc "pacman --noconfirm -U C:/tools/mingw-w64-x86_64-gcc-14.2.0-3-any.pkg.tar.zst" \
     && C:\tools\msys64\usr\bin\bash -lc "pacman --noconfirm -S base-devel mingw-w64-x86_64-make mingw-w64-x86_64-libyaml"
 
-ARG RUBY_VERSION=3.3.6.2
+ARG RUBY_VERSION=3.4.4.2
 
 # Install Ruby using Chocolatey/RubyInstaller
 RUN choco install -y ruby --version=%RUBY_VERSION%
 
 # Install bundler, fontist and metanorma dependencies
-RUN gem install "bundler:~>2.6.5" fontist
+RUN gem install "bundler:~>2.6.5" fontist pkg-config
 
 # Copy and install metanorma gem
 COPY metanorma-windows/Gemfile c:/setup/Gemfile
@@ -44,7 +44,7 @@ COPY metanorma-windows/Gemfile c:/setup/Gemfile
 RUN cd c:/setup && bundle install
 
 # Delete gem cache so it doesn't not get copied to the final image
-RUN powershell -Command "Remove-Item -Path 'C:\tools\ruby33\lib\ruby\gems\3.3.0\cache' -Recurse -Force -ErrorAction SilentlyContinue"
+RUN powershell -Command "Remove-Item -Path 'C:\tools\ruby34\lib\ruby\gems\3.4.0\cache' -Recurse -Force -ErrorAction SilentlyContinue"
 
 
 ### Final image
@@ -74,10 +74,10 @@ RUN python -m pip install --upgrade pip && \
     pip cache purge
 
 # Copy built metanorma from builder
-COPY --from=builder C:/tools/ruby33 C:/tools/ruby33
+COPY --from=builder C:/tools/ruby34 C:/tools/ruby34
 
 # Adjust PATH
-RUN setx /M PATH "%PATH%;C:\tools\ruby33\bin"
+RUN setx /M PATH "%PATH%;C:\tools\ruby34\bin"
 
 # Update fontist
 RUN fontist update


### PR DESCRIPTION
Fixes https://github.com/metanorma/metanorma-docker/issues/208 by upgrading to latest Ruby 3.4 containing a fix for the root cause

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
